### PR TITLE
Fix tinyfiledialogs not being fetchable from sourceforge

### DIFF
--- a/ports/tinyfiledialogs/portfile.cmake
+++ b/ports/tinyfiledialogs/portfile.cmake
@@ -4,8 +4,8 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
 vcpkg_from_git(
     OUT_SOURCE_PATH SOURCE_PATH
-    URL https://git.code.sf.net/p/tinyfiledialogs/code
-    REF 331f93e903e0555399bf81479114dda978a77d7c
+    URL https://github.com/native-toolkit/tinyfiledialogs
+    REF f2379486f0e516cab528fc49991ad1b36c2e2831
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})


### PR DESCRIPTION
**Describe the pull request**
Fix tinyfiledialogs not being fetchable from sourceforge. Use github instead.

- What does your PR fix? Fixes issue #
No issue was created, but i encountered issues on my local machine.

- Which triplets are supported/not supported? Have you updated the CI baseline?
No update outside of git url

- Does your PR follow the [maintainer guide](https://github.com/microsoft/vcpkg/blob/master/docs/maintainers/maintainer-guide.md)?
